### PR TITLE
 Clarify that init installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install Tome and Bookish, run these commands:
 composer create-project drupal-tome/tome-project my_site --stability dev --no-interaction
 cd my_site
 composer require drupal-tome/bookish
-drush tome:init # Select Bookish in the prompt
+vendor/bin/drush tome:init # Select Bookish in the prompt
 ```
 
 You can now commit your initial codebase, content, config, and files to Git.
@@ -49,13 +49,13 @@ You can now commit your initial codebase, content, config, and files to Git.
 To start a local webserver, run:
 
 ```
-drush runserver
+vendor/bin/drush runserver
 ```
 
 then in another tab run:
 
 ```
-drush uli -l 127.0.0.1:8888
+vendor/bin/drush uli -l 127.0.0.1:8888
 ```
 
 and click the link to start editing.
@@ -63,7 +63,7 @@ and click the link to start editing.
 To re-install your site, run:
 
 ```
-drush tome:install
+vendor/bin/drush tome:install
 ```
 
 For information on deploying your site, you can visit

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ The requirements for using Tome locally are:
 Alternatively you can run the commands below using the [mortenson/tome Docker
 image]. See the [Docker script documentation] for reference.
 
+A global Drush installation is not required to use Tome, but is easier to use than typing `vendor/bin/drush` every time you want to run a command. This guide will assume that the `drush` command is available.
+
 To install Tome and Bookish, run these commands:
 
 ```
 composer create-project drupal-tome/tome-project my_site --stability dev --no-interaction
 cd my_site
 composer require drupal-tome/bookish
-vendor/bin/drush tome:init # Select Bookish in the prompt
+drush tome:init # Select Bookish in the prompt
 ```
 
 You can now commit your initial codebase, content, config, and files to Git.
@@ -49,13 +51,13 @@ You can now commit your initial codebase, content, config, and files to Git.
 To start a local webserver, run:
 
 ```
-vendor/bin/drush runserver
+drush runserver
 ```
 
 then in another tab run:
 
 ```
-vendor/bin/drush uli -l 127.0.0.1:8888
+drush uli -l 127.0.0.1:8888
 ```
 
 and click the link to start editing.
@@ -63,7 +65,7 @@ and click the link to start editing.
 To re-install your site, run:
 
 ```
-vendor/bin/drush tome:install
+drush tome:install
 ```
 
 For information on deploying your site, you can visit

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ For information on deploying your site, you can visit
 `/admin/help/topic/bookish_help.tome` on your local site, or read the docs at
 https://tome.fyi/docs.
 
-
 ## Install (without Tome)
 
 If you don't want to use Tome, you can run this from any Drupal 9+ install:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The requirements for using Tome locally are:
 Alternatively you can run the commands below using the [mortenson/tome Docker
 image]. See the [Docker script documentation] for reference.
 
-First, run these commands:
+To install Tome and Bookish, run these commands:
 
 ```
 composer create-project drupal-tome/tome-project my_site --stability dev --no-interaction
@@ -45,12 +45,6 @@ drush tome:init # Select Bookish in the prompt
 ```
 
 You can now commit your initial codebase, content, config, and files to Git.
-
-To re-install your site, run:
-
-```
-drush tome:install
-```
 
 To start a local webserver, run:
 
@@ -66,9 +60,30 @@ drush uli -l 127.0.0.1:8888
 
 and click the link to start editing.
 
+To re-install your site, run:
+
+```
+drush tome:install
+```
+
 For information on deploying your site, you can visit
 `/admin/help/topic/bookish_help.tome` on your local site, or read the docs at
 https://tome.fyi/docs.
+
+
+## Install Tome and Bookish in Lando
+
+Run these commands to install Tome and Bookish in Lando:
+
+```
+composer create-project drupal-tome/tome-project --stability dev --no-interaction
+cd tome-project
+composer require drupal-tome/bookish
+lando init --recipe drupal9 --name tome-project --source cwd --webroot web
+lando start
+lando drush tome:init # Select Bookish in the prompt
+lando drush uli -l https://tome-project.lndo.site
+```
 
 ## Install (without Tome)
 

--- a/README.md
+++ b/README.md
@@ -71,20 +71,6 @@ For information on deploying your site, you can visit
 https://tome.fyi/docs.
 
 
-## Install Tome and Bookish in Lando
-
-Run these commands to install Tome and Bookish in Lando:
-
-```
-composer create-project drupal-tome/tome-project --stability dev --no-interaction
-cd tome-project
-composer require drupal-tome/bookish
-lando init --recipe drupal9 --name tome-project --source cwd --webroot web
-lando start
-lando drush tome:init # Select Bookish in the prompt
-lando drush uli -l https://tome-project.lndo.site
-```
-
 ## Install (without Tome)
 
 If you don't want to use Tome, you can run this from any Drupal 9+ install:


### PR DESCRIPTION
Fixes: https://github.com/drupal-tome/tome-project/issues/15

It would be great to clarify that `tome:init` in fact also installs and that Bookish is ready for use after that, and that `tome:install` is for a later re-install, so placing it last, after the web server bit.