### PR TITLE
Fix letter-spacing in menu

### DIFF
--- a/themes/bookish_theme/components/bk_more_link.sfc
+++ b/themes/bookish_theme/components/bk_more_link.sfc
@@ -11,7 +11,7 @@
     justify-content: center;
     font-weight: var(--font-weight-semibold);
     font-size: 1rem;
-    letter-spacing: 3px;
+    letter-spacing: 2px;
     align-items: center;
     margin: 0 auto;
     border-bottom: 2px solid transparent;

--- a/themes/bookish_theme/css/main.css
+++ b/themes/bookish_theme/css/main.css
@@ -295,7 +295,7 @@ input[type="submit"]:hover {
 .block-system-menu-blockmain a:hover,
 .block-system-menu-blockmain a:focus {
   color: var(--font-color);
-  letter-spacing: 3px;
+  letter-spacing: 2px;
 }
 
 .block-system-menu-blockmain a:hover,


### PR DESCRIPTION
Fixed excessive 'letter-spacing' in mobile menu items (reduced from 3px to 2px), which was causing a visual jump on small screens (~350px).